### PR TITLE
Reduce deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,17 +30,13 @@ Imports:
     cli,
     digest,
     dplyr,
-    gtools,
     lifecycle,
     methods,
-    micd,
     pcalg,
     purrr,
     R6,
-    readr,
     rlang,
     S7,
-    stringr,
     tibble,
     tidyr,
     tidyselect
@@ -54,7 +50,8 @@ Suggests:
     spelling,
     testthat (>= 3.0.0),
     withr,
-    mice
+    mice,
+    micd
 VignetteBuilder: quarto
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Imports:
     cli,
     digest,
     dplyr,
-    glue,
     gtools,
     lifecycle,
     methods,

--- a/R/knowledge-verbs.R
+++ b/R/knowledge-verbs.R
@@ -199,7 +199,6 @@ add_to_tier <- function(kn, ...) {
   .check_if_pkgs_are_installed(
     pkgs = c(
       "dplyr",
-      "glue",
       "rlang"
     ),
     function_name = "add_to_tier"
@@ -235,9 +234,9 @@ add_to_tier <- function(kn, ...) {
     # resolve variables on the RHS
     vars <- .formula_vars(kn, rhs_expr)
     if (!length(vars)) {
-      stop(glue::glue(
-        "Specification `{deparse(rhs_expr)}` matched no variables."
-      ))
+      cli::cli_abort(
+        "Specification `{paste(deparse(rhs_expr), collapse = '')}` matched no variables."
+      )
     }
 
     # detect variables already assigned to a different tier

--- a/R/tetrad-graph.R
+++ b/R/tetrad-graph.R
@@ -10,14 +10,6 @@
 #' @keywords internal
 #' @noRd
 tetrad_graph <- function(x) {
-  .check_if_pkgs_are_installed(
-    pkgs = c(
-      "readr",
-      "stringr"
-    ),
-    function_name = "tetrad_graph"
-  )
-
   if (!is.character(x) || length(x) != 1) {
     stop("`x` must be a single character string")
   }

--- a/R/tetrad-graph.R
+++ b/R/tetrad-graph.R
@@ -22,18 +22,16 @@ tetrad_graph <- function(x) {
     stop("`x` must be a single character string")
   }
 
-  parts <- stringr::str_split(x, "\n")[[1]] |>
-    (\(v) v[v != ""])()
+  parts <- strsplit(x, "\n")[[1]]
+  parts <- parts[parts != ""]
 
-  nodes <- stringr::str_split(parts[1], ",", simplify = TRUE) |>
-    as.character()
+  nodes <- strsplit(parts[1], ",")[[1]]
+  nodes <- as.character(nodes)
 
   mat_text <- paste(parts[-1], collapse = "\n")
-
-  amat <- readr::read_csv(
-    I(mat_text),
-    col_names = FALSE,
-    show_col_types = FALSE
+  amat <- utils::read.csv(
+    text = mat_text,
+    header = FALSE
   ) |>
     as.matrix()
 

--- a/R/tpc-run.R
+++ b/R/tpc-run.R
@@ -243,7 +243,7 @@ v_orient_temporal <- function(amat, sepsets) {
 
     # if there are at least two adjacent nodes
     if (length(theseAdj) >= 2) {
-      adjpairs <- gtools::combinations(length(theseAdj), 2, v = theseAdj)
+      adjpairs <- t(utils::combn(theseAdj, 2))
 
       npairs <- nrow(adjpairs)
 

--- a/R/tpc-run.R
+++ b/R/tpc-run.R
@@ -228,13 +228,6 @@ tpc_run <- function(
 #' @keywords internal
 #' @noRd
 v_orient_temporal <- function(amat, sepsets) {
-  .check_if_pkgs_are_installed(
-    pkgs = c(
-      "gtools"
-    ),
-    function_name = "v_orient_temporal"
-  )
-
   vnames <- rownames(amat) # TODO: not used
   nvar <- nrow(amat)
 

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,2 +1,5 @@
 /.quarto/
 **/*.quarto_ipynb
+*.html
+*.R
+*_files

--- a/vignettes/causalDisco.qmd
+++ b/vignettes/causalDisco.qmd
@@ -1,10 +1,13 @@
 ---
 title: "causalDisco"
+vignette: >
+  %\VignetteIndexEntry{causalDisco}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
 knitr:
   opts_chunk:
     collapse: true
-    comment: "#>"
-    fig.align: "center"
+    comment: '#>'
 ---
 
 ```{r}

--- a/vignettes/causalDisco.qmd
+++ b/vignettes/causalDisco.qmd
@@ -15,7 +15,7 @@ knitr:
 library(causalDisco)
 ```
 
-This article provides an overview of the causalDisco package, which offers tools
+This vignette provides an overview of the causalDisco package, which offers tools
 for causal discovery from observational data. It covers the main features of the
 package, including various causal discovery algorithms, knowledge incorporation,
 and result visualization.


### PR DESCRIPTION
Drops glue, gtools, readr, and stringr as dependencies completely. Moves micd to suggests. Also added the causalDisco one back as a vignette.

Fixes #41 