### PR TITLE
Improve printing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 - Added support for the RFCI algorithm via `rfci()`, interfacing with
   implementations from pcalg and Tetrad.
 
+- The infix edge operators `%-->%` and `%!-->%` in `knowledge()` now accept `+`
+  on both sides to specify multiple variables, e.g.
+  `A + B %-->% C + D` is equivalent to `c(A, B) %-->% c(C, D)`.
+
 ## Bug fixes
 
 - Fixed `knowledge()` dropping variables from `tier()` formulas when infix edge

--- a/R/disco-class.R
+++ b/R/disco-class.R
@@ -249,30 +249,30 @@ print.Disco <- function(x, ...) {
   invisible(x)
 }
 
-.print_item_line <- function(label, items, max_lines = 3L) {
+.print_item_line <- function(label, items, max_items = 10L) {
   if (!length(items)) return(invisible())
   width <- getOption("width", 80L)
   prefix <- paste0("  ", label, ": ")
   pad <- strrep(" ", nchar(prefix))
 
+  n_omitted <- max(0L, length(items) - max_items)
+  shown <- if (n_omitted > 0L) items[seq_len(max_items)] else items
+  if (n_omitted > 0L) {
+    shown <- c(shown, sprintf("... and %d more", n_omitted))
+  }
+
   lines <- character(0)
   cur <- prefix
-  n_continuation <- 0L
+  first <- TRUE
 
-  for (i in seq_along(items)) {
-    chunk <- if (i == 1L) items[[i]] else paste0(", ", items[[i]])
-
-    if (i > 1L && nchar(cur) + nchar(chunk) > width) {
-      n_continuation <- n_continuation + 1L
-      if (n_continuation > max_lines) {
-        remaining <- length(items) - i + 1L
-        cur <- paste0(cur, ", ... and ", remaining, " more")
-        break
-      }
+  for (item in shown) {
+    chunk <- if (first) item else paste0(", ", item)
+    if (!first && nchar(cur) + nchar(chunk) > width) {
       lines <- c(lines, cur)
-      cur <- paste0(pad, items[[i]])
+      cur <- paste0(pad, item)
     } else {
       cur <- paste0(cur, chunk)
+      first <- FALSE
     }
   }
 

--- a/R/disco-class.R
+++ b/R/disco-class.R
@@ -1,4 +1,4 @@
-#' @title Disco Object
+﻿#' @title Disco Object
 #'
 #' @description
 #' This S3 class wraps [caugi::caugi] graph object and a `Knowledge` object. It is the
@@ -184,7 +184,7 @@ as_disco.EssGraph <- function(
 
 #' @title Print a Disco Object
 #' @param x A `Disco` object.
-#' @inheritParams print.Knowledge
+#' @param ... Additional arguments (not used).
 #' @returns Invisibly returns the `Disco` object.
 #' @examples
 #' data(tpc_example)
@@ -199,40 +199,85 @@ as_disco.EssGraph <- function(
 #' cd_tges <- tpc(engine = "causalDisco", test = "fisher_z")
 #' disco_cd_tges <- disco(data = tpc_example, method = cd_tges, knowledge = kn)
 #' print(disco_cd_tges)
-#' print(disco_cd_tges, wide_vars = TRUE)
-#' print(disco_cd_tges, compact = TRUE)
 #'
 #' @exportS3Method print Disco
-print.Disco <- function(
-  x,
-  compact = FALSE,
-  wide_vars = FALSE,
-  ...
-) {
+print.Disco <- function(x, ...) {
   .check_if_pkgs_are_installed(
-    pkgs = c("cli", "tibble"),
+    pkgs = c("cli"),
     function_name = "print.Disco"
   )
 
-  cli::cli_h1("caugi graph")
-
-  # Graph info
-  graph_class <- x$caugi@graph_class
-
-  cli::cli_text("Graph class: {.strong {graph_class}}")
-
   cg <- x$caugi
-  if (compact) {
-    cli::cli_text("{nrow(edges(cg))} edges, {nrow(nodes(cg))} nodes")
+  graph_class <- cg@graph_class
+  nd <- nodes(cg)
+  ed <- edges(cg)
+  n_nodes <- nrow(nd)
+  n_edges <- nrow(ed)
+
+  kn <- x$knowledge
+  n_tiers <- if (!is.null(kn$tiers)) nrow(kn$tiers) else 0L
+  n_vars <- if (!is.null(kn$vars)) nrow(kn$vars) else 0L
+  n_required <- sum(kn$edges$status == "required", na.rm = TRUE)
+  n_forbidden <- sum(kn$edges$status == "forbidden", na.rm = TRUE)
+  kn_has_content <- n_tiers > 0L || n_required > 0L || n_forbidden > 0L
+
+  kn_parts <- character(0)
+  if (n_tiers > 0L) {
+    kn_parts <- c(kn_parts, paste0(n_tiers, " tier", if (n_tiers != 1L) "s"))
+  }
+  if (n_required > 0L) kn_parts <- c(kn_parts, paste0(n_required, " required"))
+  if (n_forbidden > 0L) kn_parts <- c(kn_parts, paste0(n_forbidden, " forbidden"))
+  kn_str <- if (length(kn_parts) > 0L) {
+    paste0(" | Knowledge: ", paste(kn_parts, collapse = ", "))
   } else {
-    print_section("Edges", edges(cg))
-    print_section("Nodes", nodes(cg))
+    ""
   }
 
-  # Knowledge info
-  print.Knowledge(x$knowledge, compact = compact, wide_vars = wide_vars, ...)
+  cat(sprintf("<Disco %s: %d nodes | %d edges%s>\n", graph_class, n_nodes, n_edges, kn_str))
+
+  if (kn_has_content) cat("Learned graph:\n")
+  .print_item_line("nodes", nd$name)
+  if (n_edges > 0L) {
+    .print_item_line("edges", paste0(ed$from, ed$edge, ed$to))
+  }
+
+  if (kn_has_content) {
+    cat("Knowledge:\n")
+    .print_knowledge_body(kn)
+  }
 
   invisible(x)
+}
+
+.print_item_line <- function(label, items, max_lines = 3L) {
+  if (!length(items)) return(invisible())
+  width <- getOption("width", 80L)
+  prefix <- paste0("  ", label, ": ")
+  pad <- strrep(" ", nchar(prefix))
+
+  lines <- character(0)
+  cur <- prefix
+  n_continuation <- 0L
+
+  for (i in seq_along(items)) {
+    chunk <- if (i == 1L) items[[i]] else paste0(", ", items[[i]])
+
+    if (i > 1L && nchar(cur) + nchar(chunk) > width) {
+      n_continuation <- n_continuation + 1L
+      if (n_continuation > max_lines) {
+        remaining <- length(items) - i + 1L
+        cur <- paste0(cur, ", ... and ", remaining, " more")
+        break
+      }
+      lines <- c(lines, cur)
+      cur <- paste0(pad, items[[i]])
+    } else {
+      cur <- paste0(cur, chunk)
+    }
+  }
+
+  lines <- c(lines, cur)
+  cat(paste(lines, collapse = "\n"), "\n", sep = "")
 }
 
 #' @title Summarize a Disco Object
@@ -255,16 +300,7 @@ print.Disco <- function(
 #'
 #' @exportS3Method summary Disco
 summary.Disco <- function(object, ...) {
-  cg <- object$caugi
-  # Graph info
-  cli::cli_h1("caugi graph summary")
-  cli::cli_text("Graph class: {.strong {cg@graph_class}}")
-  cli::cli_text("Nodes: {.strong {nrow(nodes(cg))}}")
-  cli::cli_text("Edges: {.strong {nrow(edges(cg))}}")
-
-  # Knowledge info
-  summary.Knowledge(object$knowledge, ...)
-
+  print(object, ...)
   invisible(object)
 }
 

--- a/R/knowledge.R
+++ b/R/knowledge.R
@@ -624,11 +624,7 @@ print.Knowledge <- function(x, ...) {
           return(invisible())
         }
         to_vars <- by_from[[from_var]]
-        rhs <- if (length(to_vars) == 1L) {
-          to_vars
-        } else {
-          paste0("c(", paste(to_vars, collapse = ", "), ")")
-        }
+        rhs <- paste(to_vars, collapse = " + ")
         cat(sprintf("  %s %s %s\n", from_var, op, rhs))
         n_shown <- n_shown + 1L
       }

--- a/R/knowledge.R
+++ b/R/knowledge.R
@@ -504,7 +504,7 @@ print.Knowledge <- function(x, ...) {
   invisible(x)
 }
 
-.print_knowledge_body <- function(x) {
+.print_knowledge_body <- function(x, max_tiers = 5L, max_edge_groups = 8L) {
   n_tiers <- if (!is.null(x$tiers)) nrow(x$tiers) else 0L
   n_vars <- if (!is.null(x$vars)) nrow(x$vars) else 0L
   n_required <- sum(x$edges$status == "required", na.rm = TRUE)
@@ -512,9 +512,14 @@ print.Knowledge <- function(x, ...) {
 
   # ---- Tiers ----
   if (n_tiers > 0L) {
-    for (lbl in x$tiers$label) {
+    show <- min(n_tiers, max_tiers)
+    for (lbl in x$tiers$label[seq_len(show)]) {
       tier_vars <- x$vars$var[!is.na(x$vars$tier) & x$vars$tier == lbl]
       .print_item_line(paste0("tier(", lbl, ")"), tier_vars)
+    }
+    if (n_tiers > max_tiers) {
+      cat(sprintf("  ... and %d more tier%s\n", n_tiers - max_tiers,
+                  if (n_tiers - max_tiers != 1L) "s" else ""))
     }
   }
 
@@ -528,12 +533,20 @@ print.Knowledge <- function(x, ...) {
 
   # ---- Edges ----
   if (n_required > 0L || n_forbidden > 0L) {
+    n_shown <- 0L
     for (status in c("required", "forbidden")) {
       op <- if (status == "required") "%-->%" else "%!-->%"
       grp <- x$edges[x$edges$status == status, , drop = FALSE]
       if (nrow(grp) == 0L) next
       by_from <- split(grp$to, grp$from)
       for (from_var in names(by_from)) {
+        if (n_shown >= max_edge_groups) {
+          n_total_groups <- length(unique(x$edges$from))
+          cat(sprintf("  ... and %d more edge group%s\n",
+                      n_total_groups - n_shown,
+                      if (n_total_groups - n_shown != 1L) "s" else ""))
+          return(invisible())
+        }
         to_vars <- by_from[[from_var]]
         rhs <- if (length(to_vars) == 1L) {
           to_vars
@@ -541,6 +554,7 @@ print.Knowledge <- function(x, ...) {
           paste0("c(", paste(to_vars, collapse = ", "), ")")
         }
         cat(sprintf("  %s %s %s\n", from_var, op, rhs))
+        n_shown <- n_shown + 1L
       }
     }
   }

--- a/R/knowledge.R
+++ b/R/knowledge.R
@@ -362,6 +362,75 @@ knowledge <- function(...) {
       fun <- as.character(expr[[1]])
     }
 
+    # Handle expressions like A + B %-->% C + D where + mixes with edge ops.
+    # R parses %any% before +, so A + B %-->% C + D becomes A + (B %-->% C) + D.
+    # Flatten the whole + chain into terms, find
+    # the single edge-op term, then attach left/right node-terms to its LHS/RHS.
+    if (is.call(expr) && identical(expr[[1]], as.name("+"))) {
+      .split_terms <- function(e) {
+        if (is.call(e) && identical(e[[1L]], as.name("+"))) {
+          c(.split_terms(e[[2L]]), .split_terms(e[[3L]]))
+        } else {
+          list(e)
+        }
+      }
+      .join_plus <- function(ts) Reduce(function(a, b) call("+", a, b), ts)
+
+      terms <- .split_terms(expr)
+      is_edge_term <- vapply(
+        terms,
+        function(t) {
+          is.call(t) && as.character(t[[1L]]) %in% c("%-->%", "%!-->%")
+        },
+        logical(1L)
+      )
+
+      if (any(is_edge_term)) {
+        if (sum(is_edge_term) > 1L) {
+          stop(
+            "Only one edge operator per + expression is supported.\n",
+            "Expression: ",
+            deparse(expr),
+            call. = FALSE
+          )
+        }
+        i <- which(is_edge_term)
+        edge_term <- terms[[i]]
+        left_terms <- terms[seq_len(i - 1L)]
+        right_terms <- if (i < length(terms)) {
+          terms[seq(i + 1L, length(terms))]
+        } else {
+          list()
+        }
+
+        natural_lhs <- edge_term[[2L]]
+        natural_rhs <- edge_term[[3L]]
+
+        new_lhs <- if (length(left_terms)) {
+          call("+", .join_plus(left_terms), natural_lhs)
+        } else {
+          natural_lhs
+        }
+        new_rhs <- if (length(right_terms)) {
+          call("+", natural_rhs, .join_plus(right_terms))
+        } else {
+          natural_rhs
+        }
+
+        new_edge <- edge_term
+        new_edge[[2L]] <- new_lhs
+        new_edge[[3L]] <- new_rhs
+
+        status <- if (identical(edge_term[[1L]], as.name("%-->%"))) {
+          "required"
+        } else {
+          "forbidden"
+        }
+        add_edge_infix(new_edge, status)
+        next
+      }
+    }
+
     # Infix required
     if (is.call(expr) && identical(expr[[1]], as.name("%-->%"))) {
       add_edge_infix(expr, "required")
@@ -518,8 +587,11 @@ print.Knowledge <- function(x, ...) {
       .print_item_line(paste0("tier(", lbl, ")"), tier_vars)
     }
     if (n_tiers > max_tiers) {
-      cat(sprintf("  ... and %d more tier%s\n", n_tiers - max_tiers,
-                  if (n_tiers - max_tiers != 1L) "s" else ""))
+      cat(sprintf(
+        "  ... and %d more tier%s\n",
+        n_tiers - max_tiers,
+        if (n_tiers - max_tiers != 1L) "s" else ""
+      ))
     }
   }
 
@@ -537,14 +609,18 @@ print.Knowledge <- function(x, ...) {
     for (status in c("required", "forbidden")) {
       op <- if (status == "required") "%-->%" else "%!-->%"
       grp <- x$edges[x$edges$status == status, , drop = FALSE]
-      if (nrow(grp) == 0L) next
+      if (nrow(grp) == 0L) {
+        next
+      }
       by_from <- split(grp$to, grp$from)
       for (from_var in names(by_from)) {
         if (n_shown >= max_edge_groups) {
           n_total_groups <- length(unique(x$edges$from))
-          cat(sprintf("  ... and %d more edge group%s\n",
-                      n_total_groups - n_shown,
-                      if (n_total_groups - n_shown != 1L) "s" else ""))
+          cat(sprintf(
+            "  ... and %d more edge group%s\n",
+            n_total_groups - n_shown,
+            if (n_total_groups - n_shown != 1L) "s" else ""
+          ))
           return(invisible())
         }
         to_vars <- by_from[[from_var]]

--- a/R/knowledge.R
+++ b/R/knowledge.R
@@ -1,4 +1,4 @@
-# ──────────────────────────────────────────────────────────────────────────────
+﻿# ──────────────────────────────────────────────────────────────────────────────
 # ─────────────────────────── Public API  ──────────────────────────────────────
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -455,8 +455,6 @@ knowledge <- function(...) {
 #' @title Print a Knowledge Object
 #'
 #' @param x A `Knowledge` object.
-#' @param compact Logical. If `TRUE`, prints a more compact summary.
-#' @param wide_vars Logical. If `TRUE`, prints the variables in a wide format.
 #' @param ... Additional arguments (not used).
 #' @returns Invisibly returns the `Knowledge` object.
 #' @examples
@@ -469,128 +467,83 @@ knowledge <- function(...) {
 #'   )
 #' )
 #' print(kn)
-#' print(kn, wide_vars = TRUE)
-#' print(kn, compact = TRUE)
 #'
 #' @exportS3Method print Knowledge
-print.Knowledge <- function(x, compact = FALSE, wide_vars = FALSE, ...) {
+print.Knowledge <- function(x, ...) {
   .check_if_pkgs_are_installed(
-    pkgs = c("cli", "tibble"),
+    pkgs = c("cli"),
     function_name = "print.Knowledge"
   )
 
-  cli::cli_h1("Knowledge object")
+  n_tiers <- if (!is.null(x$tiers)) nrow(x$tiers) else 0L
+  n_vars <- if (!is.null(x$vars)) nrow(x$vars) else 0L
+  n_required <- sum(x$edges$status == "required", na.rm = TRUE)
+  n_forbidden <- sum(x$edges$status == "forbidden", na.rm = TRUE)
 
-  # ---- If knowledge is empty, return silently ----
-  if (
-    (is.null(x$tiers) || length(x$tiers) == 0) &&
-      (is.null(x$vars) || nrow(x$vars) == 0) &&
-      (is.null(x$edges) || nrow(x$edges) == 0)
-  ) {
+  if (n_tiers == 0L && n_vars == 0L && n_required == 0L && n_forbidden == 0L) {
+    cat("<Knowledge: empty>\n")
     return(invisible(x))
   }
 
-  # ---- Print tiers ----
-  tier_vec <- if (is.data.frame(x$tiers) || tibble::is_tibble(x$tiers)) {
-    x$tiers[[1]]
-  } else {
-    x$tiers
+  parts <- character(0)
+  if (n_tiers > 0L) {
+    parts <- c(parts, paste0(n_tiers, " tier", if (n_tiers != 1L) "s"))
   }
-
-  if (length(tier_vec) > 0) {
-    print_section(
-      "Tiers",
-      tibble::tibble(tier = tier_vec),
-      header_fmt = function(hdr) {
-        sub("(\\s*)tier(.*)", "\\1\u001b[1mtier\u001b[22m\\2", hdr)
-      },
-      n_max = if (compact) 5 else 20
-    )
+  if (n_vars > 0L) {
+    parts <- c(parts, paste0(n_vars, " var", if (n_vars != 1L) "s"))
   }
-
-  # ---- Print variables ----
-  if (nrow(x$vars) > 0) {
-    if (wide_vars) {
-      # Preserve NA tiers
-      tiers_vec <- x$vars$tier
-      tiers_vec[is.na(tiers_vec)] <- "<NA>"
-
-      vars_by_tier <- split(x$vars$var, tiers_vec)
-      if (length(vars_by_tier) > 0) {
-        n_max_cols <- max(lengths(vars_by_tier))
-
-        # Pad each tier with NA
-        vars_padded <- lapply(vars_by_tier, function(v) {
-          length(v) <- n_max_cols
-          v
-        })
-
-        vars_wide <- do.call(rbind, vars_padded)
-        colnames(vars_wide) <- paste0("var", seq_len(ncol(vars_wide)))
-        vars_wide <- tibble::as_tibble(vars_wide)
-
-        tier_names <- names(vars_by_tier)
-        tier_names[tier_names == "<NA>"] <- NA
-        vars_wide <- tibble::add_column(
-          vars_wide,
-          tier = tier_names,
-          .before = 1
-        )
-        na_idx <- is.na(vars_wide$tier)
-        vars_wide <- rbind(
-          vars_wide[!na_idx, , drop = FALSE],
-          vars_wide[na_idx, , drop = FALSE]
-        )
-
-        print_section(
-          "Variables",
-          vars_wide,
-          header_fmt = function(hdr) {
-            sub("(\\s*)tier(.*)", "\\1\u001b[1mtier\u001b[22m\\2", hdr)
-          },
-          n_max = if (compact) 5 else 20
-        )
-      }
-    } else {
-      print_section(
-        "Variables",
-        x$vars,
-        header_fmt = function(hdr) {
-          sub(
-            "(\\s*)var(.*)tier(\\s*)",
-            "\\1\u001b[1mvar\u001b[22m\\2\u001b[1mtier\u001b[22m\\3",
-            hdr
-          )
-        },
-        n_max = if (compact) 5 else 20
-      )
-    }
+  if (n_required > 0L) {
+    parts <- c(parts, paste0(n_required, " required"))
   }
-
-  # ---- Print edges ----
-  if (nrow(x$edges) > 0) {
-    cli::cli_h2("Edges")
-
-    sym_arrow <- cli::symbol$arrow_right
-    bullets <- c(
-      forbidden = cli::col_red(cli::symbol$cross),
-      required = cli::col_green(cli::symbol$tick)
-    )
-
-    rows <- if (compact && nrow(x$edges) > 20) 1:20 else seq_len(nrow(x$edges))
-
-    for (i in rows) {
-      edge <- x$edges[i, ]
-      bullet <- bullets[[edge$status]] %||% cli::symbol$bullet
-      cli::cat_line(" ", bullet, "  ", edge$from, " ", sym_arrow, " ", edge$to)
-    }
-
-    if (compact && nrow(x$edges) > 20) {
-      cli::cli_text("... and {nrow(x$edges) - 20} more edges")
-    }
+  if (n_forbidden > 0L) {
+    parts <- c(parts, paste0(n_forbidden, " forbidden"))
   }
+  cat(sprintf("<Knowledge: %s>\n", paste(parts, collapse = " | ")))
 
+  .print_knowledge_body(x)
   invisible(x)
+}
+
+.print_knowledge_body <- function(x) {
+  n_tiers <- if (!is.null(x$tiers)) nrow(x$tiers) else 0L
+  n_vars <- if (!is.null(x$vars)) nrow(x$vars) else 0L
+  n_required <- sum(x$edges$status == "required", na.rm = TRUE)
+  n_forbidden <- sum(x$edges$status == "forbidden", na.rm = TRUE)
+
+  # ---- Tiers ----
+  if (n_tiers > 0L) {
+    for (lbl in x$tiers$label) {
+      tier_vars <- x$vars$var[!is.na(x$vars$tier) & x$vars$tier == lbl]
+      .print_item_line(paste0("tier(", lbl, ")"), tier_vars)
+    }
+  }
+
+  # ---- Untiered vars ----
+  if (n_vars > 0L) {
+    untiered <- x$vars$var[is.na(x$vars$tier)]
+    if (length(untiered) > 0L) {
+      .print_item_line("vars", untiered)
+    }
+  }
+
+  # ---- Edges ----
+  if (n_required > 0L || n_forbidden > 0L) {
+    for (status in c("required", "forbidden")) {
+      op <- if (status == "required") "%-->%" else "%!-->%"
+      grp <- x$edges[x$edges$status == status, , drop = FALSE]
+      if (nrow(grp) == 0L) next
+      by_from <- split(grp$to, grp$from)
+      for (from_var in names(by_from)) {
+        to_vars <- by_from[[from_var]]
+        rhs <- if (length(to_vars) == 1L) {
+          to_vars
+        } else {
+          paste0("c(", paste(to_vars, collapse = ", "), ")")
+        }
+        cat(sprintf("  %s %s %s\n", from_var, op, rhs))
+      }
+    }
+  }
 }
 
 #' @title Summarize a Knowledge Object
@@ -610,29 +563,7 @@ print.Knowledge <- function(x, compact = FALSE, wide_vars = FALSE, ...) {
 #'
 #' @exportS3Method summary Knowledge
 summary.Knowledge <- function(object, ...) {
-  cli::cli_h2("Knowledge summary")
-
-  n_tiers <- if (!is.null(object$tiers)) nrow(object$tiers) else 0
-  n_vars <- if (!is.null(object$vars)) nrow(object$vars) else 0
-
-  n_required <- sum(object$edges$status == "required", na.rm = TRUE)
-  n_forbidden <- sum(object$edges$status == "forbidden", na.rm = TRUE)
-
-  cli::cli_text("Tiers: {.strong {n_tiers}}")
-  cli::cli_text("Variables: {.strong {n_vars}}")
-  cli::cli_text("Required edges: {.strong {n_required}}")
-  cli::cli_text("Forbidden edges: {.strong {n_forbidden}}")
-
-  if (!is.null(object$tiers) && !is.null(object$vars)) {
-    cli::cli_h3("Variables per Tier")
-    tier_counts <- table(object$vars$tier)
-    for (tier_name in names(tier_counts)) {
-      cli::cli_text(
-        "{tier_name}: {.strong {tier_counts[[tier_name]]}} variables"
-      )
-    }
-  }
-
+  print(object, ...)
   invisible(object)
 }
 

--- a/tests/testthat/_snaps/knowledge.md
+++ b/tests/testthat/_snaps/knowledge.md
@@ -1,12 +1,7 @@
 # print.Knowledge() snapshot
 
-      [1mtier[22m 
-      <chr>
-    1 1    
-    2 2    
-      [1mvar[22m   [1mtier[22m 
-      <chr> <chr>
-    1 V1    1    
-    2 V2    2    
-     x  V1 > V2
+    <Knowledge: 2 tiers | 2 vars | 1 forbidden>
+      tier(1): V1
+      tier(2): V2
+      V1 %!-->% V2
 

--- a/tests/testthat/test-knowledge.R
+++ b/tests/testthat/test-knowledge.R
@@ -43,7 +43,8 @@ test_that("Knowledge object is created correctly using mini-DSL", {
 
 test_that("infix edges before tier() do not drop variables from tier() (no data frame)", {
   kn <- knowledge(
-    A %-->% C, C %!-->% D,
+    A %-->% C,
+    C %!-->% D,
     tier(
       1 ~ A + B,
       2 ~ C + D
@@ -1311,4 +1312,58 @@ test_that("print and summary method for no tier knowledge works", {
   print(kn, wide = TRUE, compact = TRUE)
   summary(kn)
   expect_true(TRUE)
+})
+
+# ──────────────────────────────────────────────────────────────────────────────
+# + syntax for infix edge operators
+# ──────────────────────────────────────────────────────────────────────────────
+
+test_that("+ on RHS of %-->% is equivalent to c()", {
+  kn_plus <- knowledge(V1 %-->% V2 + V3)
+  kn_c <- knowledge(V1 %-->% c(V2, V3))
+  expect_equal(kn_plus$edges, kn_c$edges)
+})
+
+test_that("+ on RHS of %!-->% is equivalent to c()", {
+  kn_plus <- knowledge(V1 %!-->% V2 + V3)
+  kn_c <- knowledge(V1 %!-->% c(V2, V3))
+  expect_equal(kn_plus$edges, kn_c$edges)
+})
+
+test_that("+ on LHS of %-->% is equivalent to c()", {
+  kn_plus <- knowledge(V1 + V2 %-->% V3)
+  kn_c <- knowledge(c(V1, V2) %-->% V3)
+  expect_equal(kn_plus$edges, kn_c$edges)
+})
+
+test_that("+ on LHS of %!-->% is equivalent to c()", {
+  kn_plus <- knowledge(V1 + V2 %!-->% V3)
+  kn_c <- knowledge(c(V1, V2) %!-->% V3)
+  expect_equal(kn_plus$edges, kn_c$edges)
+})
+
+test_that("+ on both sides of %-->% is equivalent to c()", {
+  kn_plus <- knowledge(V1 + V2 %-->% V3 + V4)
+  kn_c <- knowledge(c(V1, V2) %-->% c(V3, V4))
+  expect_equal(kn_plus$edges, kn_c$edges)
+})
+
+test_that("+ on both sides of %!-->% is equivalent to c()", {
+  kn_plus <- knowledge(V1 + V2 %!-->% V3 + V4)
+  kn_c <- knowledge(c(V1, V2) %!-->% c(V3, V4))
+  expect_equal(kn_plus$edges, kn_c$edges)
+})
+
+test_that("+ syntax with data and multiple edge lines matches c() syntax", {
+  kn_plus <- knowledge(
+    tpc_example,
+    child_x1 + youth_x4 %-->% child_x2 + youth_x3,
+    child_x2 %!-->% youth_x3 + oldage_x5
+  )
+  kn_c <- knowledge(
+    tpc_example,
+    c(child_x1, youth_x4) %-->% c(child_x2, youth_x3),
+    child_x2 %!-->% c(youth_x3, oldage_x5)
+  )
+  expect_equal(kn_plus$edges, kn_c$edges)
 })


### PR DESCRIPTION
The old printing printed a lot, but didn't really show much. Redesigned the printing of `Knowledge` and `Disco` objects, what do you think @ekstroem? I can then use this in the JSS paper instead of having to use plots every time.

While redesigning I noticed you couldn't use `+` syntax in `knowledge()` for infix operators, such as
`A + B %-->% C + D`, and I fixed this too. To test this PR locally run
```r
pak::pak("https://github.com/BjarkeHautop/causalDisco")
```

Showcase of output:

``` r
suppressPackageStartupMessages(library(causalDisco))
data("tpc_example")

# Only edge knowledge
kn <- knowledge(
  tpc_example,
  c(child_x1, oldage_x6) %-->% c(child_x2, youth_x3),
  child_x2 %!-->% c(youth_x3, oldage_x5)
)
kn
#> <Knowledge: 6 vars | 4 required | 2 forbidden>
#>   vars: child_x1, child_x2, oldage_x5, oldage_x6, youth_x3, youth_x4
#>   child_x1 %-->% child_x2 + youth_x3
#>   oldage_x6 %-->% child_x2 + youth_x3
#>   child_x2 %!-->% oldage_x5 + youth_x3

# Only tier knowledge:
kn2 <- knowledge(
  tpc_example,
  tier(
    1 ~ starts_with("child"),
    2 ~ starts_with("youth"),
    3 ~ starts_with("oldage")
  )
)
kn2
#> <Knowledge: 3 tiers | 6 vars>
#>   tier(1): child_x1, child_x2
#>   tier(2): youth_x3, youth_x4
#>   tier(3): oldage_x5, oldage_x6

# Both:
kn3 <- knowledge(
  tpc_example,
  child_x1 %-->% c(child_x2, youth_x3),
  child_x2 %!-->% c(youth_x3, oldage_x5),
  tier(
    1 ~ starts_with("child"),
    2 ~ starts_with("youth"),
    3 ~ starts_with("oldage")
  )
)
kn3
#> <Knowledge: 3 tiers | 6 vars | 2 required | 2 forbidden>
#>   tier(1): child_x1, child_x2
#>   tier(2): youth_x3, youth_x4
#>   tier(3): oldage_x5, oldage_x6
#>   child_x1 %-->% child_x2 + youth_x3
#>   child_x2 %!-->% oldage_x5 + youth_x3

pc_method <- pc(engine = "bnlearn", test = "fisher_z")
disco(tpc_example, pc_method)
#> <Disco PDAG: 6 nodes | 6 edges>
#>   nodes: child_x2, child_x1, youth_x4, youth_x3, oldage_x6, oldage_x5
#>   edges: child_x1---child_x2, child_x2-->oldage_x5, child_x2---youth_x4
#>          oldage_x5-->oldage_x6, youth_x3-->oldage_x5, youth_x4-->oldage_x6
disco(tpc_example, pc_method, kn)
#> <Disco PDAG: 6 nodes | 9 edges | Knowledge: 4 required, 2 forbidden>
#> Learned graph:
#>   nodes: child_x2, child_x1, youth_x4, youth_x3, oldage_x6, oldage_x5
#>   edges: child_x1-->child_x2, child_x1-->youth_x3, child_x2---youth_x4
#>          oldage_x5-->child_x2, oldage_x5-->oldage_x6, oldage_x5-->youth_x3
#>          oldage_x6-->child_x2, oldage_x6-->youth_x3, youth_x4-->oldage_x6
#> Knowledge:
#>   vars: child_x1, child_x2, oldage_x5, oldage_x6, youth_x3, youth_x4
#>   child_x1 %-->% child_x2 + youth_x3
#>   oldage_x6 %-->% child_x2 + youth_x3
#>   child_x2 %!-->% oldage_x5 + youth_x3
disco(tpc_example, pc_method, kn2)
#> <Disco PDAG: 6 nodes | 6 edges | Knowledge: 3 tiers>
#> Learned graph:
#>   nodes: child_x2, child_x1, youth_x4, youth_x3, oldage_x6, oldage_x5
#>   edges: child_x1---child_x2, child_x2-->oldage_x5, child_x2-->youth_x4
#>          oldage_x5-->oldage_x6, youth_x3-->oldage_x5, youth_x4-->oldage_x6
#> Knowledge:
#>   tier(1): child_x1, child_x2
#>   tier(2): youth_x3, youth_x4
#>   tier(3): oldage_x5, oldage_x6
disco(tpc_example, pc_method, kn3)
#> <Disco PDAG: 6 nodes | 6 edges | Knowledge: 3 tiers, 2 required, 2 forbidden>
#> Learned graph:
#>   nodes: child_x2, child_x1, youth_x4, youth_x3, oldage_x6, oldage_x5
#>   edges: child_x1-->child_x2, child_x1-->youth_x3, child_x2-->youth_x4
#>          oldage_x5-->oldage_x6, youth_x3-->oldage_x5, youth_x4-->oldage_x6
#> Knowledge:
#>   tier(1): child_x1, child_x2
#>   tier(2): youth_x3, youth_x4
#>   tier(3): oldage_x5, oldage_x6
#>   child_x1 %-->% child_x2 + youth_x3
#>   child_x2 %!-->% oldage_x5 + youth_x3




# Large data showcase:
large_data <- as.data.frame(
  matrix(
    runif(10000),
    nrow = 100,
    ncol = 100,
    byrow = TRUE
  )
)

names(large_data) <- paste0("X_", 1:100)

kn4 <- knowledge(
  large_data,
  tier(
    seq_tiers(
      1:100,
      ends_with("_{i}")
    )
  ),
  X_1 %-->% X_2
)
kn4
#> <Knowledge: 100 tiers | 100 vars | 1 required>
#>   tier(1): X_1
#>   tier(2): X_2
#>   tier(3): X_3
#>   tier(4): X_4
#>   tier(5): X_5
#>   ... and 95 more tiers
#>   X_1 %-->% X_2

disco(large_data, pc_method, kn4)
#> <Disco PDAG: 100 nodes | 96 edges | Knowledge: 100 tiers, 1 required>
#> Learned graph:
#>   nodes: X_1, X_2, X_3, X_4, X_5, X_6, X_7, X_8, X_9, X_10, ... and 90 more
#>   edges: X_1-->X_2, X_1-->X_49, X_12-->X_36, X_13-->X_40, X_13-->X_62
#>          X_14-->X_33, X_14-->X_97, X_16-->X_80, X_17-->X_82, X_17-->X_98
#>          ... and 86 more
#> Knowledge:
#>   tier(1): X_1
#>   tier(2): X_2
#>   tier(3): X_3
#>   tier(4): X_4
#>   tier(5): X_5
#>   ... and 95 more tiers
#>   X_1 %-->% X_2
```

<sup>Created on 2026-06-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>



Notes for myself:

- Deprecate `summary()` and old args in print/summary
- Add entry to news
- Improve vignette and examples to use new syntax of knowledge for infix operators
- Record graph class PAG since caugi doesn't support it yet. Then when printing PAGs we can say PAG instead of UNKNOWN.